### PR TITLE
fix: update fetch request to omit credentials so cross-origin req works

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -137,7 +137,9 @@ import { features } from "./index.astro";
     const APPCAST_URL = "https://dl.getmythic.app/updates/update.xml";
 
     async function fetchLatestRelease() {
-      const response = await fetch(APPCAST_URL).catch((error) => {
+      const response = await fetch(APPCAST_URL, {
+        credentials: "omit",
+      }).catch((error) => {
         console.error("Error fetching latest release:", error);
         return null;
       });


### PR DESCRIPTION
This pull request makes a small update to the way the latest release is fetched in the `src/pages/download.astro` file. The change ensures that browser credentials (such as cookies) are not sent with the request to the appcast URL, improving privacy and potentially avoiding authentication issues.

* Set the `credentials` option to `"omit"` in the `fetch` call for `APPCAST_URL` in `src/pages/download.astro`.