### PR TITLE
fix: revert `APPCAST_URL` while we find a solution to bypass cors

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -134,12 +134,10 @@ import { features } from "./index.astro";
   </style>
 
   <script>
-    const APPCAST_URL = "https://dl.getmythic.app/updates/update.xml";
+    const APPCAST_URL = "https://getmythic.app/appcast.xml";
 
     async function fetchLatestRelease() {
-      const response = await fetch(APPCAST_URL, {
-        credentials: "omit",
-      }).catch((error) => {
+      const response = await fetch(APPCAST_URL).catch((error) => {
         console.error("Error fetching latest release:", error);
         return null;
       });


### PR DESCRIPTION
This pull request updates the application update feed URL in the download page to point to the new location and simplifies the fetch request for the latest release.

Download page update:

* Changed the value of `APPCAST_URL` in `src/pages/download.astro` to use `https://getmythic.app/appcast.xml` instead of the previous `https://dl.getmythic.app/updates/update.xml`.
* Removed the `credentials: "omit"` option from the `fetch` call, simplifying the request.